### PR TITLE
Create package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "yuidoc-themes",
+  "description": "Custom themes for the YUIDoc documentation generator.",
+  "version": "0.1.0",
+  "keywords": [
+    "yuidoc",
+    "theme",
+    "smooth",
+    "neat"
+  ],
+  "author": {
+    "name": "Krxtopher",
+    "email": "unknown@exemple.com"
+  },
+  "contributors": [
+    {
+      "name": "Jean-cédric Thérond",
+      "email": "jean-cedric.therond@cellfishmedia.fr"
+    }
+  ],
+  "dependencies": {
+  },
+  "homepage": "https://github.com/Krxtopher/yuidoc-themes",
+  "bugs": "https://github.com/Krxtopher/yuidoc-themes/issues",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/Krxtopher/yuidoc-themes.git"
+  },
+  "licenses": [
+    {
+      "type": "unknown",
+      "url": "none"
+    }
+  ],
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}


### PR DESCRIPTION
Just to allow people to use npm install with something like that in their own package.json: 

```
"devDependencies": {
  "grunt": "~0.4.5",
  "grunt-contrib-yuidoc": "^0.5.2",
  "yuidoc-themes": "Krxtopher/yuidoc-themes"
}
```

It's more convenience than real killer feature.
